### PR TITLE
Update database URL format in Dockerfile for Keycloak configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV KC_PROXY_HEADERS=xforwarded
 ENV KEYCLOAK_ADMIN=$ADMIN
 ENV KEYCLOAK_ADMIN_PASSWORD=$ADMIN_PASSWORD
 ENV KB_DB=postgres
-ENV KC_DB_URL="jdbc:postgresql://${DB_URL}/${DB_DATABASE}?sslmode=require"
+ENV KC_DB_URL="postgres://postgres:${DB_PASSWORD}@${DB_URL}/${DB_DATABASE}"
 
 # db may seem redundant but it is not
 RUN /opt/keycloak/bin/kc.sh build --db=postgres
@@ -74,7 +74,7 @@ ENV KC_PROXY_HEADERS=xforwarded
 ENV KEYCLOAK_ADMIN=$ADMIN
 ENV KEYCLOAK_ADMIN_PASSWORD=$ADMIN_PASSWORD
 ENV KB_DB=postgres
-ENV KC_DB_URL='jdbc:postgresql://${DB_URL}/${DB_DATABASE}?sslmode=require'
+ENV KC_DB_URL="postgres://postgres:${DB_PASSWORD}@${DB_URL}/${DB_DATABASE}"
 
 EXPOSE 8443
 EXPOSE 8444


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to update the database URL format for Keycloak configuration. The most important changes include modifying the `KC_DB_URL` environment variable to use a simpler connection string format.

Changes to Keycloak database URL configuration:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L35-R35): Updated `KC_DB_URL` to use the format `postgres://postgres:${DB_PASSWORD}@${DB_URL}/${DB_DATABASE}` instead of the previous JDBC URL format. This change was applied in two places within the file. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L35-R35) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L77-R77)