### PR TITLE
Change KC_DB_URL in Dockerfile to use single quotes for consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV KC_PROXY_HEADERS=xforwarded
 ENV KEYCLOAK_ADMIN=$ADMIN
 ENV KEYCLOAK_ADMIN_PASSWORD=$ADMIN_PASSWORD
 ENV KB_DB=postgres
-ENV KC_DB_URL="postgres://postgres:${DB_PASSWORD}@${DB_URL}/${DB_DATABASE}"
+ENV KC_DB_URL='postgres://postgres:${DB_PASSWORD}@${DB_URL}/${DB_DATABASE}'
 
 # db may seem redundant but it is not
 RUN /opt/keycloak/bin/kc.sh build --db=postgres
@@ -74,7 +74,7 @@ ENV KC_PROXY_HEADERS=xforwarded
 ENV KEYCLOAK_ADMIN=$ADMIN
 ENV KEYCLOAK_ADMIN_PASSWORD=$ADMIN_PASSWORD
 ENV KB_DB=postgres
-ENV KC_DB_URL="postgres://postgres:${DB_PASSWORD}@${DB_URL}/${DB_DATABASE}"
+ENV KC_DB_URL='postgres://postgres:${DB_PASSWORD}@${DB_URL}/${DB_DATABASE}'
 
 EXPOSE 8443
 EXPOSE 8444


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change modifies the `KC_DB_URL` environment variable to use single quotes instead of double quotes.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L35-R35): Changed the `KC_DB_URL` environment variable to use single quotes instead of double quotes. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L35-R35) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L77-R77)